### PR TITLE
INFSEC-839: chore(runtime): bump action runtime from node16 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ outputs:
   version:
     description: 'The new semantic version'
 runs:
-  using: 'node16'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "action-tag-semver",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",
         "@actions/exec": "^1.1.1",
@@ -15,7 +15,7 @@
         "semver": "^7.3.7"
       },
       "devDependencies": {
-        "@types/node": "^16.11.56",
+        "@types/node": "^24.0.0",
         "@types/semver": "^7.3.12",
         "@vercel/ncc": "^0.34.0",
         "typescript": "^4.8.2"
@@ -164,10 +164,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.11.56",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
-      "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==",
-      "dev": true
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.3.12",
@@ -279,6 +283,13 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
@@ -456,10 +467,13 @@
       }
     },
     "@types/node": {
-      "version": "16.11.56",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
-      "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==",
-      "dev": true
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~7.16.0"
+      }
     },
     "@types/semver": {
       "version": "7.3.12",
@@ -534,6 +548,12 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true
     },
     "universal-user-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "semver": "^7.3.7"
       },
       "devDependencies": {
-        "@types/node": "^24.0.0",
+        "@types/node": "^20.0.0",
         "@types/semver": "^7.3.12",
         "@vercel/ncc": "^0.34.0",
         "typescript": "^4.8.2"
@@ -164,13 +164,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/semver": {
@@ -285,9 +285,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -467,12 +467,12 @@
       }
     },
     "@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "requires": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/semver": {
@@ -551,9 +551,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "semver": "^7.3.7"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0",
+    "@types/node": "^20.0.0",
     "@types/semver": "^7.3.12",
     "@vercel/ncc": "^0.34.0",
     "typescript": "^4.8.2"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "semver": "^7.3.7"
   },
   "devDependencies": {
-    "@types/node": "^16.11.56",
+    "@types/node": "^24.0.0",
     "@types/semver": "^7.3.12",
     "@vercel/ncc": "^0.34.0",
     "typescript": "^4.8.2"


### PR DESCRIPTION
## Summary

`action.yml` `runs.using`: **node16 → node24**. Plus `@types/node ^16 → ^20` for dev typings.

`dist/index.js` is the bundled runtime artifact; source is unchanged. `@actions/*` libs use only stable Node APIs, so the existing bundle runs on node24 unchanged.

## Why

`node16` was deprecated on GitHub Actions runners over a year ago. Every consumer CI run currently emits a node-version warning. node24 is the target of the org-wide Node 24 GitHub Actions migration (parent: [INFSEC-654](https://agora-systems.atlassian.net/browse/INFSEC-654), hard cutover June 2 2026).

## Why `@types/node@^20` (not `^24`)

`@types/node@24` requires `typescript >= 5.8`, but this repo pins `typescript@^4.8.2` (and `@vercel/ncc@^0.34.0`). Bumping `@types/node` to `^24` would break `npm run build` until the whole TS toolchain is upgraded — out of scope for this runtime migration.

`@types/node@^20` is the highest line compatible with `typescript@^4.8.2`. The dev typings drift from the node24 runtime is harmless here because `src/index.ts` uses no Node APIs directly (only `@actions/core`, `@actions/exec`, `@actions/github`, `semver`). A full TS/ncc/dep upgrade can be tracked separately.

Verified locally: `npm install` + `npm run build` pass cleanly, producing a `714 kB dist/index.js` (same size as before).

## Rollout strategy: move floating `v1`

All 6 consumer repos pin `@v1`. Once this PR merges, **force-update the `v1` tag** to the new HEAD so all consumers pick up node24 on their next CI run — no consumer PRs needed.

| Repo | File |
|---|---|
| kojo-ai-explorer | `.github/workflows/build.yml` |
| kojo-billing-cost-extractor | `.github/workflows/build.yml` |
| marketplace | `.github/workflows/bump-semantic-version.yml` |
| smart-scanning | `.github/workflows/build.yml` |
| sync-client | `.github/workflows/deploy.yml` |
| web | `.github/workflows/bump-semantic-version.yml` |

All consumer workflows run on `ubuntu-latest` (GitHub-hosted) — past the `v2.327.1` runner floor needed for node24.

## Test plan

- [ ] After merging + tag move, trigger a `version-bump` job in `kojo-ai-explorer` (push to `main`) → confirm:
  - Step succeeds and tags the next semver
  - No `Node.js 16 actions are deprecated` warning in the run summary
- [ ] Spot-check one other consumer (e.g. `web`) on its next merge to main

## Tickets

- [INFSEC-839](https://agora-systems.atlassian.net/browse/INFSEC-839) — this PR
- [INFSEC-654](https://agora-systems.atlassian.net/browse/INFSEC-654) — parent (org-wide Node 24 migration)
- [INFSEC-838](https://agora-systems.atlassian.net/browse/INFSEC-838) — kojo-ai-explorer node24 PR (sibling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)